### PR TITLE
List requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+jupyter
+tensorflow
+matplotlib
+scikit-learn
+seaborn
+pandas
+nltk
+textblob
+requests
+numpy
+tqdm


### PR DESCRIPTION
Adds a list of project dependencies for easy one-off setup.

Usage:
```
pip3 install -r requirements.txt
```